### PR TITLE
Fix compatibility with latest Fabric API + TerraBlender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.4.+" apply false
+    id "dev.architectury.loom" version "1.5-SNAPSHOT" apply false
 }
 
 architectury {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     implementation("blue.endless:jankson:${rootProject.jankson_version}")
 
     modImplementation "com.github.glitchfiend:TerraBlender-common:${rootProject.minecraft_version}-${rootProject.terrablender_version}"
+    // Required by TerraBlender
+    compileOnly "com.electronwill.night-config:core:3.6.7"
+    compileOnly "com.electronwill.night-config:toml:3.6.7"
 }
 
 publishing {

--- a/common/src/main/java/net/cristellib/mixin/MixinTerrablenderConfig.java
+++ b/common/src/main/java/net/cristellib/mixin/MixinTerrablenderConfig.java
@@ -4,18 +4,17 @@ import net.cristellib.util.TerrablenderUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import terrablender.config.Config;
 import terrablender.config.TerraBlenderConfig;
 
 @Mixin(value = TerraBlenderConfig.class, remap = false)
 public class MixinTerrablenderConfig {
-    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lterrablender/config/Config;addNumber(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;"))
-    private <T extends Number & Comparable<T>> Number create(Config instance, String comment, String key, T defaultValue, T min, T max) {
+    @Redirect(method = "load()V", at = @At(value = "INVOKE", target = "terrablender/config/TerraBlenderConfig.addNumber(Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;)Ljava/lang/Number;"))
+    private <T extends Number & Comparable<T>> Number create(TerraBlenderConfig instance, String key, T defaultValue, T min, T max, String comment) {
         if (TerrablenderUtil.mixinEnabled() && key.equals("vanilla_overworld_region_weight")) {
             if (defaultValue instanceof Integer) {
                 return 0;
             }
         }
-        return instance.addNumber(comment, key, defaultValue, min, max);
+        return instance.addNumber(key, defaultValue, min, max, comment);
     }
 }

--- a/fabric-like/src/main/java/net/cristellib/fabriclike/CristelLibFabricLikePlatform.java
+++ b/fabric-like/src/main/java/net/cristellib/fabriclike/CristelLibFabricLikePlatform.java
@@ -26,7 +26,7 @@ public class CristelLibFabricLikePlatform {
     public static PackResources registerBuiltinResourcePack(ResourceLocation id, Component displayName, String modid) {
         ModContainer container = FabricLoader.getInstance().getModContainer(modid).orElse(null);
         if(container != null){
-            return ModNioResourcePack.create(id.getPath(), container, id.getPath(), PackType.SERVER_DATA, ResourcePackActivationType.ALWAYS_ENABLED);
+            return ModNioResourcePack.create(id.getPath(), container, id.getPath(), PackType.SERVER_DATA, ResourcePackActivationType.ALWAYS_ENABLED, true);
         }
         else {
             CristelLib.LOGGER.warn("Couldn't get mod container for modid: " + modid);

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,15 +7,15 @@ archives_base_name=cristellib
 mod_version=1.2.1
 maven_group=net.cristellib
 
-fabric_loader_version=0.15.1
-fabric_api_version=0.91.2+1.20.4
+fabric_loader_version=0.15.3
+fabric_api_version=0.95.3+1.20.4
 
-forge_version=1.20.4-49.0.3
-neoforge_version=20.4.72-beta
+forge_version=1.20.4-49.0.22
+neoforge_version=20.4.137-beta
 
 
-quilt_loader_version=0.22.0
-quilt_fabric_api_version=7.3.1+0.89.3-1.20.1
+quilt_loader_version=0.23.0
+quilt_fabric_api_version=7.4.0+0.90.0-1.20.1
 
 jankson_version=1.2.3
-terrablender_version=3.3.0.4
+terrablender_version=3.3.0.10


### PR DESCRIPTION
This PR adjusts the parameters of `ModNioResourcePack#create` in `fabric-like/src/main/java/net/cristellib/fabriclike/CristelLibFabricLikePlatform.java` to account for changes in recent versions of Fabric API (fixing a crash), and updates the mixin into `TerraBlenderConfig` for recent versions of TerraBlender (allowing the mod to compile).

It also updates the dependency versions accordingly.