### PR TITLE
Fix incompat with Terrablender's End Backport

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation("blue.endless:jankson:${rootProject.jankson_version}")
 
     modImplementation "com.github.glitchfiend:TerraBlender-fabric:${rootProject.minecraft_version}-${rootProject.terrablender_version}"
+    compileOnly("com.electronwill.night-config:core:3.6.7")
 }
 
 publishing {

--- a/common/src/main/java/net/cristellib/mixin/MixinTerrablenderConfig.java
+++ b/common/src/main/java/net/cristellib/mixin/MixinTerrablenderConfig.java
@@ -4,18 +4,17 @@ import net.cristellib.util.TerrablenderUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import terrablender.config.Config;
 import terrablender.config.TerraBlenderConfig;
 
 @Mixin(value = TerraBlenderConfig.class, remap = false)
 public class MixinTerrablenderConfig {
-    @Redirect(method = "<init>", at = @At(value = "INVOKE", target = "Lterrablender/config/Config;addNumber(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Ljava/lang/Number;"))
-    private <T extends Number & Comparable<T>> Number create(Config instance, String comment, String key, T defaultValue, T min, T max) {
+    @Redirect(method = "load()V", at = @At(value = "INVOKE", target = "terrablender/config/TerraBlenderConfig.addNumber(Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;)Ljava/lang/Number;"))
+    private <T extends Number & Comparable<T>> Number create(TerraBlenderConfig instance, String key, T defaultValue, T min, T max, String comment) {
         if (TerrablenderUtil.mixinEnabled() && key.equals("vanilla_overworld_region_weight")) {
             if (defaultValue instanceof Integer) {
                 return 0;
             }
         }
-        return instance.addNumber(comment, key, defaultValue, min, max);
+        return instance.addNumber(key, defaultValue, min, max, comment);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ quilt_loader_version=0.21.2
 quilt_fabric_api_version=7.4.0+0.90.0-1.20.1
 
 jankson_version=1.2.3
-terrablender_version=3.0.0.169
+terrablender_version=3.0.1.5


### PR DESCRIPTION
Backports 667f5b6b900a847ce6c061769c4c9a7067a3f91c. Depends on https://github.com/Glitchfiend/TerraBlender/pull/204, but we can actually use version 3.0.1.5 for building already, as that, and only that, version contains the backport code as well.

