### PR TITLE
Fix Windows crash: normalize path separators before building ResourceLocation (1.21.10)

### DIFF
--- a/common/src/main/java/de/cristelknight/cristellib/autoconfig/ModFinder.java
+++ b/common/src/main/java/de/cristelknight/cristellib/autoconfig/ModFinder.java
@@ -55,7 +55,8 @@ public class ModFinder {
 
     private static ResourceLocation getLocation(Path rootPath) {
         String namespace = rootPath.getName(1).toString();
-        String path = Util.cutFileType(rootPath.subpath(4, rootPath.getNameCount()));
+        String rawPath = Util.cutFileType(rootPath.subpath(4, rootPath.getNameCount()));
+        String path = Util.normalizeResourcePath(rawPath);
 
         if(namespace.equals(CristelLib.MC_ID)) {
             return ResourceLocation.withDefaultNamespace(path);

--- a/common/src/main/java/de/cristelknight/cristellib/util/Util.java
+++ b/common/src/main/java/de/cristelknight/cristellib/util/Util.java
@@ -59,6 +59,39 @@ public class Util {
     }
 
     /**
+     * Normalizes a potential Minecraft resource path fragment to forward slashes.
+     *
+     * Inputs:
+     *  - path: A platform-dependent path fragment (e.g., produced from java.nio.file.Path)
+     *
+     * Behavior:
+     *  - Replaces all '\\' with '/'
+     *  - Removes a single leading '/' if present
+     *  - Collapses duplicate '/'
+     *
+     * Output:
+     *  - A normalized path string safe to pass to ResourceLocation.fromNamespaceAndPath
+     */
+    public static String normalizeResourcePath(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("Path cannot be null");
+        }
+
+        String normalized = path.replace('\\', '/');
+
+        if (!normalized.isEmpty() && normalized.charAt(0) == '/') {
+            normalized = normalized.substring(1);
+        }
+
+        // Collapse any accidental duplicate slashes
+        while (normalized.contains("//")) {
+            normalized = normalized.replace("//", "/");
+        }
+
+        return normalized;
+    }
+
+    /**
      * Parses a filename into namespace and path parts using a custom separator.
      *
      * @param fileName the filename to parse


### PR DESCRIPTION
This PR fixes a Windows-only bootstrap crash caused by backslashes leaking into ResourceLocation paths when scanning datapack structure sets.

- Problem
  - On Windows, filesystem paths use “\”. When Cristel Lib builds ResourceLocation from a Path, the resulting identifier can include backslashes (e.g. mvs:other_decoration\wooden_wheat_farm), which fails validation with “Non [a-z0-9/._-] character in path”.
- Root cause
  - Paths derived from java.nio.file.Path were not normalized to forward slashes before creating the ResourceLocation.
- Solution
  - Add a small helper to normalize path fragments to forward slashes and collapse duplicates.
  - Use the normalized path in ModFinder.getLocation before constructing the ResourceLocation.