### PR TITLE
Fix charset encoding issue causing crashes on non-UTF-8 systems

### DIFF
--- a/common/src/main/java/de/cristelknight/cristellib/builtinpacks/RuntimePack.java
+++ b/common/src/main/java/de/cristelknight/cristellib/builtinpacks/RuntimePack.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -271,7 +272,7 @@ public class RuntimePack implements PackResources {
         IoSupplier<InputStream> stream = this.getResource(PackType.SERVER_DATA, location);
         JsonObject jsonObject;
         try {
-            jsonObject = GsonHelper.parse(new BufferedReader(new InputStreamReader(stream.get())));
+            jsonObject = GsonHelper.parse(new BufferedReader(new InputStreamReader(stream.get(), StandardCharsets.UTF_8)));
         } catch (IOException | NullPointerException ex) {
             CristelLib.LOGGER.error("Couldn't get JsonObject from location: {}", location, ex);
             return null;

--- a/common/src/main/java/de/cristelknight/cristellib/config/ConfigManager.java
+++ b/common/src/main/java/de/cristelknight/cristellib/config/ConfigManager.java
@@ -23,6 +23,7 @@ import net.minecraft.resources.ResourceLocation;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -149,7 +150,7 @@ public class ConfigManager {
         } catch (IOException e) {
             throw new IllegalArgumentException(getWithPrefix(String.format("Couldn't load %s, crashing instead. Maybe try to delete the config files!", path)));
         }
-        com.google.gson.JsonElement load = JsonParser.parseReader(new InputStreamReader(stream));
+        com.google.gson.JsonElement load = JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
         return readElement(errorMsg, codec, JsonOps.INSTANCE, load);
     }
 

--- a/common/src/main/java/de/cristelknight/cristellib/util/JanksonUtil.java
+++ b/common/src/main/java/de/cristelknight/cristellib/util/JanksonUtil.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -35,9 +36,9 @@ public class JanksonUtil {
             CristelLib.LOGGER.warn("Couldn't create Input Stream for Path {}", pathC, e);
             return null;
         }
-        try (InputStreamReader reader = new InputStreamReader(im)) {
+        try (InputStreamReader reader = new InputStreamReader(im, StandardCharsets.UTF_8)) {
             return JsonParser.parseReader(reader);
-        } catch (IOException | MalformedJsonException e) {
+        } catch (IOException e) {
             CristelLib.LOGGER.warn("Couldn't read {} from mod: {}", location, getDataFromModId, e);
             return null;
         }


### PR DESCRIPTION
## Summary

Fixes game crashes on Windows systems with non-UTF-8 default encoding (e.g., GBK for Chinese, Shift-JIS for Japanese, Korean, etc.) by explicitly specifying UTF-8 charset when reading JSON files.

Fixes 
- [x] #48

## Problem

Cristel Lib 3.0.0 was causing crashes on Windows systems where the system locale is not UTF-8. The issue affected:
- **All The Mods 10 (ATM10)** players upgrading from v4.12 to v4.13
- Windows users with system locale set to Chinese (GBK), Japanese (Shift-JIS), Korean (EUC-KR), or other non-UTF-8 encodings

**Root cause:** `InputStreamReader` without explicit charset specification uses the system default encoding. On non-UTF-8 systems, this caused UTF-8 JSON files to be decoded incorrectly, resulting in malformed JSON and subsequent crashes during mod initialization.

## Solution

Added explicit `StandardCharsets.UTF_8` to all `InputStreamReader` constructors when reading JSON files:

- **JanksonUtil.java:40** - Fixed JSON parsing from mod resources
- **ConfigManager.java:153** - Fixed config file reading
- **RuntimePack.java:275** - Fixed runtime pack resource parsing

## Testing

✅ Builds successfully on all platforms (Fabric & NeoForge)
✅ Verified to work on Windows with GBK encoding (Chinese locale)
✅ No changes to functionality on UTF-8 systems

## Technical Details

Changed from:
```java
new InputStreamReader(stream)  // Uses system default charset
```

To:
```java
new InputStreamReader(stream, StandardCharsets.UTF_8)  // Explicit UTF-8
```

This ensures consistent behavior across all platforms and locales, following the same pattern already used in `RuntimePackUtil.java`.